### PR TITLE
Add table to README, missing bibtex tags, PDFs and newlines in domain READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # domains
-This is a repository containing domain and problem instances for Hierarchical Task Network (HTN) planning. At the time being (November 2020), the domains and problem instances contained in this repository were submitted for the [International Planning Competition (IPC) 2020](http://ipc2020.hierarchical-task.net), which was devoted exclusively to HTN planning. These domains and instances were not used for a range of different reasons. Please refer to the IPC booklet (to appear) for further information on these domains and problem instances.
+This is a repository containing domain and problem instances for Hierarchical Task Network (HTN) planning.
+At the time being (November 2020), the domains and problem instances contained in this repository were submitted for the [International Planning Competition (IPC) 2020](http://ipc2020.hierarchical-task.net), which was devoted exclusively to HTN planning.
+These domains and instances were not used for a range of different reasons. Please refer to the IPC booklet (to appear) for further information on these domains and problem instances.
 
 All domains and problem instances are described in HDDL, the hierarchical domain description language [1] [(PDF)](https://ojs.aaai.org/index.php/AAAI/article/view/6542/6398).
 
@@ -20,3 +22,30 @@ The IPC 2020 was organized by Gregor Behnke, Daniel Höller, and Pascal Bercher.
    doi       = {10.1609/aaai.v34i06.6542}
 } 
 ```
+
+**Total Order**
+Domain | Problems | Papers | License
+--- | ---: | --- | ---
+[Barman](total-order/Barman) | 20 | [Paper](https://www.researchgate.net/publication/320492086_Grounding_of_HTN_Planning_Domain "Grounding of HTN Planning Domain") | ?
+[Blocksworld-Learned-ECAI-16](total-order/Blocksworld-Learned-ECAI-16) | 35 | [Paper1](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf "Constructing hierarchical task models using invariance analysis") [Paper2](https://www.tdx.cat/handle/10803/458525#page=1 "Novel approaches for generalized planning") | ?
+[Depots-Learned-ECAI-16](total-order/Depots-Learned-ECAI-16) | 22 | [Paper1](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf "Constructing hierarchical task models using invariance analysis") [Paper2](https://www.tdx.cat/handle/10803/458525#page=1 "Novel approaches for generalized planning") | ?
+[Driverlog-Learned-ECAI-16](total-order/Driverlog-Learned-ECAI-16) | 20 | [Paper1](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf "Constructing hierarchical task models using invariance analysis") [Paper2](https://www.tdx.cat/handle/10803/458525#page=1 "Novel approaches for generalized planning") | ?
+[Entertainment-CE](total-order/Entertainment-CE) | 12 | [Paper1](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181 "totSAT-Totally-ordered hierarchical planning through SAT") [Paper2](https://aaai.org/ocs/index.php/ICAPS/ICAPS18/paper/view/17764/16969 "A generic method to guide HTN progression search with classical heuristics") | ?
+[Factories](total-order/Factories) | 20 | TBA [Description](total-order/Factories/domain.pdf) | CC BY-NC-SA 4.0
+[Gripper_new](total-order/Gripper_new) | 20 | [Paper](https://ojs.aaai.org/index.php/ICAPS/article/view/3502/3370 "Tree-REX: SAT-based Tree Exploration for Efficient and High-Quality HTN Planning") | ?
+[Miconic](total-order/Miconic) | 7 | [Paper](http://www.cs.umd.edu/~nau/papers/dix2003planning.pdf "Planning in Answer Set Programming Using Ordered Task Decomposition") | ?
+[Rover-PANDA](total-order/Rover-PANDA) | 20 | [Paper](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181 "totSAT-Totally-ordered hierarchical planning through SAT") | ?
+[Rovers-Learned-ECAI-16](total-order/Rovers-Learned-ECAI-16) | 20 | [Paper1](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf "Constructing hierarchical task models using invariance analysis") [Paper2](https://www.tdx.cat/handle/10803/458525#page=1 "Novel approaches for generalized planning") | ?
+[Satellite-Learned-ECAI-16](total-order/Satellite-Learned-ECAI-16) | 20 | [Paper1](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf "Constructing hierarchical task models using invariance analysis") [Paper2](https://www.tdx.cat/handle/10803/458525#page=1 "Novel approaches for generalized planning") | ?
+[Satellite-PANDA](total-order/Satellite-PANDA) | 25 | [Paper1](https://oparu.uni-ulm.de/xmlui/handle/123456789/1072 "Hybrid Planning & Scheduling") [Paper2](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181 "totSAT-Totally-ordered hierarchical planning through SAT") | ?
+[SmartPhone](total-order/SmartPhone) | 7 | [Paper1](https://hierarchical-task.net/pb/2011/Biundo2011AdvancedAssistance.pdf "Advanced user assistance based on AI planning") [Paper2](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181 "totSAT-Totally-ordered hierarchical planning through SAT") | ?
+[UM-Translog](total-order/UM-Translog) | 22 | [Paper1](https://oparu.uni-ulm.de/xmlui/handle/123456789/1072 "Hybrid Planning & Scheduling") [Paper2](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181 "totSAT-Totally-ordered hierarchical planning through SAT") | ?
+[Zenotravel](total-order/Zenotravel) | 5 | [Paper](http://www.cs.umd.edu/~nau/papers/dix2003planning.pdf "Planning in Answer Set Programming Using Ordered Task Decomposition") | ?
+[Zenotravel-Learned-ECAI-16](total-order/Zenotravel-Learned-ECAI-16) | 20 | [Paper1](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf "Constructing hierarchical task models using invariance analysis") [Paper2](https://www.tdx.cat/handle/10803/458525#page=1 "Novel approaches for generalized planning") | ?
+
+**Partial Order**
+Domain | Problems | Papers | License
+--- | ---: | --- | ---
+[Monroe](partial-order/Monroe) | 100 | [Paper1](https://www.cs.rochester.edu/research/cisd/pubs/2005/blaylock-allen-um2005.pdf "Generating artificial corpora for plan recognition") [Paper2](https://www.cs.rochester.edu/research/cisd/resources/monroe-plan/monroePlanCorpus.pdf "The Monroe Plan Corpus: Documentation") | ?
+[SmartPhone](partial-order/SmartPhone) | 7 | [Paper](https://hierarchical-task.net/pb/2011/Biundo2011AdvancedAssistance.pdf "Advanced user assistance based on AI planning") | ?
+[Zenotravel](partial-order/Zenotravel) | 5 | [Paper](http://www.cs.umd.edu/~nau/papers/dix2003planning.pdf "Planning in Answer Set Programming Using Ordered Task Decomposition") | ?

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The IPC 2020 was organized by Gregor Behnke, Daniel Höller, and Pascal Bercher.
 
 [1] paper describing HDDL:
 
-```
+```bibtex
 @InProceedings{Hoeller2020HDDL,
    author    = {Daniel H\"oller and Gregor Behnke and Pascal Bercher and Susanne Biundo and Humbert Fiorino and Damien Pellier and Ron Alford},
    title     = {HDDL: An Extension to PDDL for Expressing Hierarchical Planning Problems},
@@ -20,7 +20,7 @@ The IPC 2020 was organized by Gregor Behnke, Daniel Höller, and Pascal Bercher.
    pages     = {9883--9891},
    publisher = {AAAI Press},
    doi       = {10.1609/aaai.v34i06.6542}
-} 
+}
 ```
 
 **Total Order**

--- a/partial-order/Monroe/README.md
+++ b/partial-order/Monroe/README.md
@@ -3,6 +3,9 @@ Nate Blaylock <no known mail>
 
 edited by Daniel Höller <hoeller@cs.uni-saarland.de>
 
+# Website
+https://www.cs.rochester.edu/research/cisd/resources/monroe-plan/
+
 ## Paper
-Generating artificial corpora for plan recognition, Nate Blaylock, James Allen, User Modeling 2005
-The Monroe Plan Corpus: Documentation, Nate Blaylock, 2010
+Generating artificial corpora for plan recognition, Nate Blaylock, James Allen, User Modeling 2005. [PDF](https://www.cs.rochester.edu/research/cisd/pubs/2005/blaylock-allen-um2005.pdf)  
+The Monroe Plan Corpus: Documentation, Nate Blaylock, 2010. [PDF](https://www.cs.rochester.edu/research/cisd/resources/monroe-plan/monroePlanCorpus.pdf)

--- a/partial-order/Monroe/README.md
+++ b/partial-order/Monroe/README.md
@@ -3,7 +3,7 @@ Nate Blaylock <no known mail>
 
 edited by Daniel Höller <hoeller@cs.uni-saarland.de>
 
-# Website
+## Website
 https://www.cs.rochester.edu/research/cisd/resources/monroe-plan/
 
 ## Paper

--- a/partial-order/SmartPhone/README.md
+++ b/partial-order/SmartPhone/README.md
@@ -11,6 +11,7 @@ edited (removed "hybrid" features) by Gregor Behnke <behnkeg@informatik.uni-frei
 
 ## Paper
 
+```bibtex
 @Article{Biundo11CognitiveSystems,
   author    = {Susanne Biundo and Pascal Bercher and Thomas Geier and Felix M\"uller and Bernd Schattenberg},
   title     = {Advanced user assistance based on {AI} planning},
@@ -24,3 +25,4 @@ edited (removed "hybrid" features) by Gregor Behnke <behnkeg@informatik.uni-frei
   note      = {Special Issue on Complex Cognition},
   doi       = {10.1016/j.cogsys.2010.12.005}
 }
+```

--- a/partial-order/SmartPhone/README.md
+++ b/partial-order/SmartPhone/README.md
@@ -1,10 +1,7 @@
-## Author
-Bastian Seegebarth <no known mail>
-
-Bernd Schattenberg <mail@berndschattenberg.de>
-
-Pascal Bercher <pascal.bercher@alumni.uni-ulm.de>
-
+## Authors
+Bastian Seegebarth <no known mail>  
+Bernd Schattenberg <mail@berndschattenberg.de>  
+Pascal Bercher <pascal.bercher@alumni.uni-ulm.de>  
 Susanne Biundo <susanne.biundo@uni-ulm.de>
 
 edited (removed "hybrid" features) by Gregor Behnke <behnkeg@informatik.uni-freiburg.de>
@@ -26,3 +23,5 @@ edited (removed "hybrid" features) by Gregor Behnke <behnkeg@informatik.uni-frei
   doi       = {10.1016/j.cogsys.2010.12.005}
 }
 ```
+
+[PDF](https://hierarchical-task.net/pb/2011/Biundo2011AdvancedAssistance.pdf)

--- a/partial-order/Zenotravel/README.md
+++ b/partial-order/Zenotravel/README.md
@@ -2,4 +2,4 @@
 Jürgen Dix <dix@tu-clausthal.de>
 
 ## Paper
-Planning in Answer Set Programming Using Ordered Task Decomposition, Jürgen Dix, Ugur Kuter, Dana Nau, KI, 2003
+Planning in Answer Set Programming Using Ordered Task Decomposition, Jürgen Dix, Ugur Kuter, Dana Nau, KI, 2003. [PDF](http://www.cs.umd.edu/~nau/papers/dix2003planning.pdf)

--- a/total-order/Barman/README.md
+++ b/total-order/Barman/README.md
@@ -1,8 +1,8 @@
-## Author
-Abdeldjalil Ramoul <abdeldjalil.ramoul@cloud-temple.com>
-Damien Pellier <damien.pellier@univ-grenoble-alpes.fr>
-Humbert Fiorino <humbert.fiorino@univ-grenoble-alpes.fr>
+## Authors
+Abdeldjalil Ramoul <abdeldjalil.ramoul@cloud-temple.com>  
+Damien Pellier <damien.pellier@univ-grenoble-alpes.fr>  
+Humbert Fiorino <humbert.fiorino@univ-grenoble-alpes.fr>  
 Sylvie Pesty <sylvie.pesty@univ-grenoble-alpes.fr>
 
 ## Paper
-Grounding of HTN Planning Domain, Abdeldjalil Ramoul, Damien Pellier, Humbert Fiorino, Sylvie Pesty, IJAIT, 2017
+Grounding of HTN Planning Domain, Abdeldjalil Ramoul, Damien Pellier, Humbert Fiorino, Sylvie Pesty, IJAIT, 2017. [PDF]((https://www.researchgate.net/publication/320492086_Grounding_of_HTN_Planning_Domain)

--- a/total-order/Blocksworld-Learned-ECAI-16/README.md
+++ b/total-order/Blocksworld-Learned-ECAI-16/README.md
@@ -1,11 +1,11 @@
-## Author
-Damir Lotinac <dlotinac@gmail.com>
-Filippos Kominis <filippos.kominis@gmail.com>
+## Authors
+Damir Lotinac <dlotinac@gmail.com>  
+Filippos Kominis <filippos.kominis@gmail.com>  
 Anders Jonsson <anders.jonsson@upf.edu>
 
-## Repo
+## Repository
 https://github.com/dloti/pddl-to-htn/tree/HDDL-no-helpers
 
 ## Paper
-Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016
-Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017
+Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016. [PDF](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf)  
+Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017. [PDF](https://www.tdx.cat/handle/10803/458525#page=1)

--- a/total-order/Depots-Learned-ECAI-16/README.md
+++ b/total-order/Depots-Learned-ECAI-16/README.md
@@ -1,11 +1,11 @@
-## Author
-Damir Lotinac <dlotinac@gmail.com>
-Filippos Kominis <filippos.kominis@gmail.com>
+## Authors
+Damir Lotinac <dlotinac@gmail.com>  
+Filippos Kominis <filippos.kominis@gmail.com>  
 Anders Jonsson <anders.jonsson@upf.edu>
 
-## Repo
+## Repository
 https://github.com/dloti/pddl-to-htn/tree/HDDL-no-helpers
 
 ## Paper
-Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016
-Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017
+Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016. [PDF](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf)  
+Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017. [PDF](https://www.tdx.cat/handle/10803/458525#page=1)

--- a/total-order/Driverlog-Learned-ECAI-16/README.md
+++ b/total-order/Driverlog-Learned-ECAI-16/README.md
@@ -1,11 +1,11 @@
-## Author
-Damir Lotinac <dlotinac@gmail.com>
-Filippos Kominis <filippos.kominis@gmail.com>
+## Authors
+Damir Lotinac <dlotinac@gmail.com>  
+Filippos Kominis <filippos.kominis@gmail.com>  
 Anders Jonsson <anders.jonsson@upf.edu>
 
-## Repo
+## Repository
 https://github.com/dloti/pddl-to-htn/tree/HDDL-no-helpers
 
 ## Paper
-Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016
-Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017
+Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016. [PDF](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf)  
+Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017. [PDF](https://www.tdx.cat/handle/10803/458525#page=1)

--- a/total-order/Entertainment-CE/README.md
+++ b/total-order/Entertainment-CE/README.md
@@ -2,5 +2,5 @@
 Daniel Höller <hoeller@cs.uni-saarland.de>
 
 ## Paper
-totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018
-A generic method to guide HTN progression search with classical heuristics, D. Höller, P. Bercher, G. Behnke, S. Biundo, ICAPS, 2018
+totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018. [PDF](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181)  
+A generic method to guide HTN progression search with classical heuristics, D. Höller, P. Bercher, G. Behnke, S. Biundo, ICAPS, 2018. [PDF](https://aaai.org/ocs/index.php/ICAPS/ICAPS18/paper/view/17764/16969)

--- a/total-order/Factories/README.md
+++ b/total-order/Factories/README.md
@@ -1,9 +1,9 @@
 ## Authors
-Dominik Schreiber <dominik.schreiber@kit.edu>
+Dominik Schreiber <dominik.schreiber@kit.edu>  
 Malte Sönnichsen <malte@soennichsen.xyz>
 
 ## Paper
 not published yet
 
 ## License
-CC BY-NC-SA 4.0 
+CC BY-NC-SA 4.0

--- a/total-order/Gripper_new/README.md
+++ b/total-order/Gripper_new/README.md
@@ -1,8 +1,7 @@
-## Author
-- Damien Pellier <damien.pellier@univ-grenoble-alpes.fr>
-- Humbert Fiorino <humbert.fiorino@univ-grenoble-alpes.fr> 
-- Arnaud Lequen <arnaud.lequen@ens-rennes.fr>
-
+## Authors
+Damien Pellier <damien.pellier@univ-grenoble-alpes.fr>  
+Humbert Fiorino <humbert.fiorino@univ-grenoble-alpes.fr>  
+Arnaud Lequen <arnaud.lequen@ens-rennes.fr>
 
 ## Paper
-Tree-REX: SAT-based Tree Exploration for Efficient and High-Quality HTN Planning, Dominik Schreiber, Damien Pellier, Humbert Fiorino, Tomas Balyo, ICAPS, 2019
+Tree-REX: SAT-based Tree Exploration for Efficient and High-Quality HTN Planning, Dominik Schreiber, Damien Pellier, Humbert Fiorino, Tomas Balyo, ICAPS, 2019. [PDF](https://ojs.aaai.org/index.php/ICAPS/article/view/3502/3370)

--- a/total-order/Miconic/README.md
+++ b/total-order/Miconic/README.md
@@ -4,4 +4,4 @@ Jürgen Dix <dix@tu-clausthal.de>
 edited by Gregor Behnke <behnkeg@informatik.uni-freiburg.de>
 
 ## Paper
-Planning in Answer Set Programming Using Ordered Task Decomposition, Jürgen Dix, Ugur Kuter, Dana Nau, KI, 2003
+Planning in Answer Set Programming Using Ordered Task Decomposition, Jürgen Dix, Ugur Kuter, Dana Nau, KI, 2003. [PDF](http://www.cs.umd.edu/~nau/papers/dix2003planning.pdf)

--- a/total-order/Rover-PANDA/README.md
+++ b/total-order/Rover-PANDA/README.md
@@ -4,4 +4,4 @@ Daniel Höller <hoeller@cs.uni-saarland.de>
 edited by Gregor Behnke <behnkeg@informatik.uni-freiburg.de>
 
 ## Paper
-totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018
+totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018. [PDF](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181)

--- a/total-order/Rovers-Learned-ECAI-16/README.md
+++ b/total-order/Rovers-Learned-ECAI-16/README.md
@@ -1,11 +1,11 @@
-## Author
-Damir Lotinac <dlotinac@gmail.com>
-Filippos Kominis <filippos.kominis@gmail.com>
+## Authors
+Damir Lotinac <dlotinac@gmail.com>  
+Filippos Kominis <filippos.kominis@gmail.com>  
 Anders Jonsson <anders.jonsson@upf.edu>
 
-## Repo
+## Repository
 https://github.com/dloti/pddl-to-htn/tree/HDDL-no-helpers
 
 ## Paper
-Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016
-Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017
+Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016. [PDF](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf)  
+Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017. [PDF](https://www.tdx.cat/handle/10803/458525#page=1)

--- a/total-order/Satellite-Learned-ECAI-16/README.md
+++ b/total-order/Satellite-Learned-ECAI-16/README.md
@@ -1,11 +1,11 @@
-## Author
-Damir Lotinac <dlotinac@gmail.com>
-Filippos Kominis <filippos.kominis@gmail.com>
+## Authors
+Damir Lotinac <dlotinac@gmail.com>  
+Filippos Kominis <filippos.kominis@gmail.com>  
 Anders Jonsson <anders.jonsson@upf.edu>
 
-## Repo
+## Repository
 https://github.com/dloti/pddl-to-htn/tree/HDDL-no-helpers
 
 ## Paper
-Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016
-Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017
+Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016. [PDF](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf)  
+Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017. [PDF](https://www.tdx.cat/handle/10803/458525#page=1)

--- a/total-order/Satellite-PANDA/README.md
+++ b/total-order/Satellite-PANDA/README.md
@@ -5,13 +5,15 @@ edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <
 
 ## Paper
 
+```bibtex
 @PhdThesis{Schattenberg09HybridPlanningAndScheduling,
   author    = {Bernd Schattenberg},
   title     = {Hybrid Planning \& Scheduling},
   school    = {Ulm University, Germany},
   year      = {2009},
-  doi       = {10.18725/OPARU-1045},
+  doi       = {10.18725/OPARU-1045}
 }
+```
 
 The domain was converted to a totally ordered domain for the following paper:
 totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018

--- a/total-order/Satellite-PANDA/README.md
+++ b/total-order/Satellite-PANDA/README.md
@@ -15,5 +15,7 @@ edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <
 }
 ```
 
+[PDF](https://oparu.uni-ulm.de/xmlui/handle/123456789/1072)
+
 The domain was converted to a totally ordered domain for the following paper:
-totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018
+totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018. [PDF](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181)

--- a/total-order/SmartPhone/README.md
+++ b/total-order/SmartPhone/README.md
@@ -1,10 +1,7 @@
-## Author
-Bastian Seegebarth <no known mail>
-
-Bernd Schattenberg <mail@berndschattenberg.de>
-
-Pascal Bercher <pascal.bercher@alumni.uni-ulm.de>
-
+## Authors
+Bastian Seegebarth <no known mail>  
+Bernd Schattenberg <mail@berndschattenberg.de>  
+Pascal Bercher <pascal.bercher@alumni.uni-ulm.de>  
 Susanne Biundo <susanne.biundo@uni-ulm.de>
 
 edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <behnkeg@informatik.uni-freiburg.de>
@@ -27,5 +24,7 @@ edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <
 }
 ```
 
+[PDF](https://hierarchical-task.net/pb/2011/Biundo2011AdvancedAssistance.pdf)
+
 The domain was converted to a totally ordered domain for the following paper:
-totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018
+totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018. [PDF](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181)

--- a/total-order/SmartPhone/README.md
+++ b/total-order/SmartPhone/README.md
@@ -11,6 +11,7 @@ edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <
 
 ## Paper
 
+```bibtex
 @Article{Biundo11CognitiveSystems,
   author    = {Susanne Biundo and Pascal Bercher and Thomas Geier and Felix M\"uller and Bernd Schattenberg},
   title     = {Advanced user assistance based on {AI} planning},
@@ -24,6 +25,7 @@ edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <
   note      = {Special Issue on Complex Cognition},
   doi       = {10.1016/j.cogsys.2010.12.005}
 }
+```
 
 The domain was converted to a totally ordered domain for the following paper:
 totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018

--- a/total-order/UM-Translog/README.md
+++ b/total-order/UM-Translog/README.md
@@ -15,5 +15,7 @@ edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <
 }
 ```
 
+[PDF](https://oparu.uni-ulm.de/xmlui/handle/123456789/1072)
+
 The domain was converted to a totally ordered domain for the following paper:
-totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018
+totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018. [PDF](https://www.aaai.org/ocs/index.php/AAAI/AAAI18/paper/view/16820/16181)

--- a/total-order/UM-Translog/README.md
+++ b/total-order/UM-Translog/README.md
@@ -5,6 +5,7 @@ edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <
 
 ## Paper
 
+```bibtex
 @PhdThesis{Schattenberg09HybridPlanningAndScheduling,
   author    = {Bernd Schattenberg},
   title     = {Hybrid Planning \& Scheduling},
@@ -12,6 +13,7 @@ edited (removed "hybrid" features and converted to TO domain) by Gregor Behnke <
   year      = {2009},
   doi       = {10.18725/OPARU-1045}
 }
+```
 
 The domain was converted to a totally ordered domain for the following paper:
 totSAT-Totally-ordered hierarchical planning through SAT, Gregor Behnke, Daniel Höller, Susanne Biundo, AAAI, 2018

--- a/total-order/Zenotravel-Learned-ECAI-16/README.md
+++ b/total-order/Zenotravel-Learned-ECAI-16/README.md
@@ -1,11 +1,11 @@
-## Author
-Damir Lotinac <dlotinac@gmail.com>
-Filippos Kominis <filippos.kominis@gmail.com>
+## Authors
+Damir Lotinac <dlotinac@gmail.com>  
+Filippos Kominis <filippos.kominis@gmail.com>  
 Anders Jonsson <anders.jonsson@upf.edu>
 
-## Repo
+## Repository
 https://github.com/dloti/pddl-to-htn/tree/HDDL-no-helpers
 
 ## Paper
-Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016
-Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017
+Constructing hierarchical task models using invariance analysis; Damir Lotinac, Anders Jonsson; ECAI 2016. [PDF](https://pdfs.semanticscholar.org/93e8/f422f8ce4ab102b2a4d2e4cd57af19e605b8.pdf)  
+Novel approaches for generalized planning; Damir Lotinac;Diss. Universitat Pompeu Fabra 2017. [PDF](https://www.tdx.cat/handle/10803/458525#page=1)

--- a/total-order/Zenotravel/README.md
+++ b/total-order/Zenotravel/README.md
@@ -4,4 +4,4 @@ Jürgen Dix <dix@tu-clausthal.de>
 edited by Gregor Behnke <behnkeg@informatik.uni-freiburg.de>
 
 ## Paper
-Planning in Answer Set Programming Using Ordered Task Decomposition, Jürgen Dix, Ugur Kuter, Dana Nau, KI, 2003
+Planning in Answer Set Programming Using Ordered Task Decomposition, Jürgen Dix, Ugur Kuter, Dana Nau, KI, 2003. [PDF](http://www.cs.umd.edu/~nau/papers/dix2003planning.pdf)


### PR DESCRIPTION
This PR adds a table to the main README, and missing bibtex tags, PDF links and newlines to domain READMEs.
Note that some information is missing from the table, as some papers are not available yet or licenses are not found.
The missing bibtex tags improve readability a little bit, perhaps we could add a bibtex to each README reference in the future.
The two spaces added to the end of some lines force a newline in Markdown, which improves listing authors and papers.

I would like someone to double check to see if I linked not only the right paper, but a good source, to avoid links breaking in the future.